### PR TITLE
Ontologies example and updates of Ontology API

### DIFF
--- a/examples/01-02-ontologies.ipynb
+++ b/examples/01-02-ontologies.ipynb
@@ -1,0 +1,214 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Branje ontologij s strežnika\n",
+    "\n",
+    "Primer uporabe API-ja za prenos ontologije iz strežnika, branje in izpisovanje ontologije."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import tempfile\n",
+    "import shutil\n",
+    "\n",
+    "from textsemantics import OntologyAPI\n",
+    "from utils.ontology_utils import print_onto_tree\n",
+    "from owlready2 import onto_path, Thing, World"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ustvarimo povezavo s strežnikom. Pri povezovanju na strežnik projekta, ni potrebno podati naslova strežnika. Nato pridobimo imena vseh ontologij, ki so na voljo na strežniku in jih izpišemo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "core-sskj-only.owl\n",
+      "eli-slo.owl\n"
+     ]
+    }
+   ],
+   "source": [
+    "api = OntologyAPI()\n",
+    "ontologies = api.list_ontologies()\n",
+    "print(\"\\n\".join(ontologies))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Izbrali smo ontologijo `core-sskj-only.owl`. Ustvarimo začasni direktorij in v njega prenesemo ontologijo ter ontologije, ki jih dana ontologija potrebuje. Uporabimo že obstoječo povezavo do strežnika."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dirpath = tempfile.mkdtemp()\n",
+    "ontology_name = \"core-sskj-only.owl\"\n",
+    "api.download_ontology(ontology_name, dirpath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Odpremo ontologijo in izraze v njej izpišemo v drevesni strukturi."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "* Owlready2 * WARNING: AnnotationProperty http://onto.mju.gov.si/centralni-besednjak-core#status belongs to more than one entity types: [owl.DatatypeProperty, owl.AnnotationProperty]; I'm trying to fix it...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "├── Agencija\n",
+      "├── BancniRacun\n",
+      "├── Dejavnost\n",
+      "├── Delez\n",
+      "├── DelniskaDruzba\n",
+      "├── Dovoljenje\n",
+      "├── Drazba\n",
+      "├── Drustvo\n",
+      "├── Funkcija\n",
+      "├── Imenik\n",
+      "├── Indikator\n",
+      "├── Informacija\n",
+      "├── Izdatek\n",
+      "├── Izplacilo\n",
+      "│   └── Placa\n",
+      "├── Izvajalec\n",
+      "├── Katalog\n",
+      "├── Klasifikacija\n",
+      "├── Kraj\n",
+      "├── Ministrstvo\n",
+      "├── Motor\n",
+      "├── Narocilo\n",
+      "├── Narocnik\n",
+      "├── Naslov\n",
+      "├── Oblika\n",
+      "│   └── FormatPodatkov\n",
+      "├── Odlocba\n",
+      "├── Organ\n",
+      "├── Oseba\n",
+      "│   ├── Clan\n",
+      "│   ├── Nadzornik\n",
+      "│   └── Zastopnik\n",
+      "├── Podatek\n",
+      "├── Podjetje\n",
+      "├── Ponudba\n",
+      "├── Pravica\n",
+      "├── PravnaPodlaga\n",
+      "├── Prijavitelj\n",
+      "├── Seznam\n",
+      "├── Sklep\n",
+      "├── Slovar\n",
+      "├── SpletnoMesto\n",
+      "│   └── SpletnaStran\n",
+      "├── Sporazum\n",
+      "├── Standard\n",
+      "├── Stanje\n",
+      "├── Status\n",
+      "├── Subvencija\n",
+      "├── Tabela\n",
+      "├── TelekomunikacijskaStoritev\n",
+      "│   ├── ElektronskaPosta\n",
+      "│   ├── Telefaks\n",
+      "│   └── Telefon\n",
+      "├── Uporaba\n",
+      "├── Uprava\n",
+      "├── Ustanovitelj\n",
+      "├── Vozilo\n",
+      "│   └── Plovilo\n",
+      "├── Zavezanec\n",
+      "├── ZbirkaPodatkov\n",
+      "├── Zbornica\n",
+      "├── Concept\n",
+      "├── ConceptScheme\n",
+      "└── Collection\n",
+      "    └── OrderedCollection\n"
+     ]
+    }
+   ],
+   "source": [
+    "# dodaj pot do direktorija v onto_path, da knjižni owlready2 ve od kod uvoziti ontologije\n",
+    "# na katerih ontologija bazira\n",
+    "if dirpath not in onto_path:\n",
+    "    onto_path.append(dirpath)\n",
+    "\n",
+    "world = World()\n",
+    "onto = world.get_ontology(\"file://\" + os.path.join(dirpath, ontology_name)).load()\n",
+    "\n",
+    "with onto:\n",
+    "    print_onto_tree(Thing, world)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ko končamo z delom, izbrišemo začasni direktorij iz računalnika."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shutil.rmtree(dirpath)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/utils/ontology_utils.py
+++ b/examples/utils/ontology_utils.py
@@ -1,0 +1,21 @@
+# prefix components:
+space = '    '
+branch = '│   '
+# pointers:
+tee = '├── '
+last = '└── '
+
+
+def print_onto_tree(class_, world, prefix: str = ''):
+    """A recursive generator, given a directory Path object
+    will yield a visual tree structure line by line
+    with each line prefixed by the same characters
+    """
+    classes_ = list(class_.subclasses(world=world))
+    # contents each get pointers that are ├── with a final └── :
+    pointers = [tee] * (len(classes_) - 1) + [last]
+    for pointer, cl in zip(pointers, classes_):
+        print(prefix + pointer + cl.name)
+        extension = branch if pointer == tee else space
+        # i.e. space because last, └── , above so no more |
+        print_onto_tree(cl, world, prefix=prefix+extension)

--- a/textsemantics/__init__.py
+++ b/textsemantics/__init__.py
@@ -1,0 +1,2 @@
+from .ontology_api import *
+from .server_api import *

--- a/textsemantics/ontology_api.py
+++ b/textsemantics/ontology_api.py
@@ -38,7 +38,7 @@ class OntologyAPI:
             yaml.safe_load(io.StringIO(f.result().content.decode("utf-8")))
             for f in futures
         ]
-        return [os.path.splitext(m["ontology file"])[0] for m in mds]
+        return [m["ontology file"] for m in mds]
 
     def download_ontology(self, ontology_name: str, path: str) -> None:
         """
@@ -52,6 +52,7 @@ class OntologyAPI:
         path
             Location to save ontology on the local computer
         """
+        ontology_name = os.path.splitext(ontology_name)[0]
         meta_file = requests.get(f"{self.server_url}{ontology_name}.yaml")
         meta_file.raise_for_status()  # raise when 404
         meta = yaml.safe_load(io.StringIO(meta_file.content.decode("utf-8")))


### PR DESCRIPTION
- Update ontology API such that it returns ontology names with file extensions.
- Add import to __init__.py such that OntologyAPI is imported with `from text-semantics import OntologyAPI`
- Adds Jupyter notebook with the example of the use of OntologyAPI